### PR TITLE
Remove registerAssetBundle from settings.twig

### DIFF
--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -15,7 +15,6 @@
 
 {% import "_includes/forms" as forms %}
 
-{% do view.registerAssetBundle("enupal\\snapshot\\assetbundles\\snapshot\\SnapshotAsset") %}
 <p>{{"Please download and install"}} <a href="https://wkhtmltopdf.org/">wkhtmltopdf</a> {{ "0.12.x in order to use Enupal Snapshot."|t('enupal-snapshot')}}
 	<a href="https://wkhtmltopdf.org/downloads.html"> download here</a>
 </p>


### PR DESCRIPTION
850ff4698cd700f5851de4033a293fb825686957 removed SnapshotAsset but the admin template was still registering it causing a rendering error. This change simply removes that registration.